### PR TITLE
Update league/commonmark due to security issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "guzzlehttp/uri-template": "^1.0",
         "laravel/prompts": "^0.1.9",
         "laravel/serializable-closure": "^1.3",
-        "league/commonmark": "^2.2.1",
+        "league/commonmark": "^2.6.0",
         "league/flysystem": "^3.8.0",
         "monolog/monolog": "^3.0",
         "nesbot/carbon": "^2.67",


### PR DESCRIPTION
Update requirement for league/commonmark as versions bellow 2.6 are vulnerable (https://github.com/advisories/GHSA-c2pc-g5qf-rfrf).
The correct version was already downloaded due to the caret but Security Analysis tools like Grype and Trivi check also the installed.json file which register the original value and trigger a High security risk in their reports.
